### PR TITLE
Update payment_tool.js Decimal place

### DIFF
--- a/erpnext/accounts/doctype/payment_tool/payment_tool.js
+++ b/erpnext/accounts/doctype/payment_tool/payment_tool.js
@@ -109,6 +109,7 @@ frappe.ui.form.on("Payment Tool", "get_outstanding_vouchers", function(frm) {
 					invoice_detail.against_voucher_no = d.voucher_no;
 					invoice_detail.total_amount = d.invoice_amount;
 					invoice_detail.outstanding_amount = d.outstanding_amount;
+					invoice_detail.outstanding_amount = invoice_detail.outstanding_amount.toFixed(2);
 				});
 			}
 			refresh_field("payment_tool_details");


### PR DESCRIPTION
This update will fix the decimal issue of the Payment tool when it gets the Outstanding amount from Purchase Invoice. .toFixed(2) is a javascript code that will round off float values to decimal place of 2 or .00 which is the standard currency format.
![fixed issue](https://cloud.githubusercontent.com/assets/9443819/6243979/8ae5c3ba-b787-11e4-92f1-0944352fbce1.jpg)
